### PR TITLE
Enabling concurrency and switching version workflow to support protec…

### DIFF
--- a/.github/workflows/eslint-config-push-main.yaml
+++ b/.github/workflows/eslint-config-push-main.yaml
@@ -9,7 +9,10 @@ on:
 jobs:
   version:
     if: ${{ !contains(github.event.head_commit.message, '#skip') }}
-    uses: iwsllc/workflows/.github/workflows/version.yaml@v2
+    concurrency:
+      group: 'versioning-automation'
+      cancel-in-progress: false
+    uses: iwsllc/workflows/.github/workflows/version-as-app.yaml@main
     with:
       ref: main
       cache: npm
@@ -18,6 +21,9 @@ jobs:
       version-command: npm version patch -w packages/eslint-config
       version-workspace: packages/eslint-config
       tag-includes-name: true
+    secrets:
+      IWS_VERSION_BOT_PK: ${{ secrets.IWS_VERSION_BOT_PK}}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   publish:
     needs: version
     if: ${{ !contains(github.event.head_commit.message, '#skip') }}

--- a/.github/workflows/fetch-push-main.yaml
+++ b/.github/workflows/fetch-push-main.yaml
@@ -20,7 +20,10 @@ jobs:
   version:
     needs: tests
     if: ${{ !contains(github.event.head_commit.message, '#skip') }}
-    uses: iwsllc/workflows/.github/workflows/version.yaml@v2
+    concurrency:
+      group: 'versioning-automation'
+      cancel-in-progress: false
+    uses: iwsllc/workflows/.github/workflows/version-as-app.yaml@main
     with:
       ref: main
       registry-url: 'https://registry.npmjs.org'
@@ -30,6 +33,9 @@ jobs:
       version-command: npm version patch -w packages/fetch
       version-workspace: packages/fetch
       tag-includes-name: true
+    secrets:
+      IWS_VERSION_BOT_PK: ${{ secrets.IWS_VERSION_BOT_PK}}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   publish:
     needs: version
     if: ${{ !contains(github.event.head_commit.message, '#skip') }}

--- a/.github/workflows/tsconfig-push-main.yaml
+++ b/.github/workflows/tsconfig-push-main.yaml
@@ -9,7 +9,10 @@ on:
 jobs:
   version:
     if: ${{ !contains(github.event.head_commit.message, '#skip') }}
-    uses: iwsllc/workflows/.github/workflows/version.yaml@v2
+    concurrency:
+      group: 'versioning-automation'
+      cancel-in-progress: false
+    uses: iwsllc/workflows/.github/workflows/version-as-app.yaml@main
     with:
       ref: main
       cache: npm
@@ -18,6 +21,9 @@ jobs:
       version-command: npm version patch -w packages/tsconfig
       version-workspace: packages/tsconfig
       tag-includes-name: true
+    secrets:
+      IWS_VERSION_BOT_PK: ${{ secrets.IWS_VERSION_BOT_PK}}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   publish:
     needs: version
     if: ${{ !contains(github.event.head_commit.message, '#skip') }}


### PR DESCRIPTION
 - `main` is now protected, so I'm switching the workflow out with another strategy impersonating git ops with a GitHub App so we can bypass rules. 
 - concurrency added at the version job level. 