### PR TITLE
Small tweaks to ErrorResponse assumptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8487,7 +8487,7 @@
     },
     "packages/fetch": {
       "name": "@iwsio/fetch",
-      "version": "2.0.31",
+      "version": "2.1.0-alpha.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/fetch",
-  "version": "2.0.31",
+  "version": "2.1.0-alpha.1",
   "license": "BSD-3-Clause",
   "description": "A simple set of functions to enable typed fetching using built-in fetch.",
   "repository": "github:iwsllc/shared-public-packages",

--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -34,7 +34,7 @@ describe('Index', () => {
 				} catch (err) {
 					expect(err).toBeInstanceOf(FetchError)
 					expect(err.isJson).toEqual(true)
-					expect(err.message).toEqual('not found')
+					expect(err.message).toEqual('Request failed')
 					expect(err.body.error).toEqual('not found')
 					expect(err.body.stack).toEqual('stack')
 				}
@@ -47,7 +47,7 @@ describe('Index', () => {
 				} catch (err) {
 					expect(err).toBeInstanceOf(FetchError)
 					expect(err.isJson).toEqual(false)
-					expect(err.message).toEqual('Request failed - Not found')
+					expect(err.message).toEqual('Request failed')
 					expect(err.body).toEqual('Not found')
 				}
 			})

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -1,9 +1,8 @@
 import { fetchTyped } from './fetchTyped.js'
 import { resolveResponse } from './resolveResponse.js'
-import { ErrorBody, FetchArgs } from './types.js'
+import { FetchArgs } from './types.js'
 
 export * from './FetchError.js'
-export * from './isErrorBody.js'
 export * from './isFetchError.js'
 export * from './types.js'
 
@@ -25,7 +24,7 @@ export { fetchTyped, resolveResponse }
  * @param defaultOptions Default request options. See MDN RequestInit/fetch
  * @returns
  */
-export function setupFetch<E extends ErrorBody>(baseUrl: string = '', defaultOptions: Partial<RequestInit> = {}) {
+export function setupFetch<E = unknown>(baseUrl: string = '', defaultOptions: Partial<RequestInit> = {}) {
 	async function fetchWithDefaultOptions<T, E>(endpoint: string, options: FetchArgs = {}) {
 		return await fetchTyped<T, E>(`${baseUrl}${endpoint}`, options, defaultOptions)
 	}

--- a/packages/fetch/src/isErrorBody.ts
+++ b/packages/fetch/src/isErrorBody.ts
@@ -1,6 +1,0 @@
-import { ErrorBody } from './types.js'
-
-export const isErrorBody = (body: unknown): body is ErrorBody => {
-	if (body == null) return false
-	return typeof body === 'object' && 'error' in body
-}

--- a/packages/fetch/src/isFetchError.ts
+++ b/packages/fetch/src/isFetchError.ts
@@ -1,4 +1,3 @@
 import { FetchError } from './FetchError.js'
-import { ErrorBody } from './types.js'
 
-export const isFetchError = <E extends ErrorBody>(error: unknown): error is FetchError<E> => error instanceof FetchError
+export const isFetchError = <E = unknown>(error: unknown): error is FetchError<E> => error instanceof FetchError

--- a/packages/fetch/src/resolveResponse.test.ts
+++ b/packages/fetch/src/resolveResponse.test.ts
@@ -1,5 +1,4 @@
 import { FetchError } from './FetchError.js'
-import { isErrorBody } from './isErrorBody.js'
 import { isFetchError } from './isFetchError.js'
 import { resolveResponse } from './resolveResponse.js'
 
@@ -23,15 +22,14 @@ describe('resolveResponse', () => {
 	})
 
 	it('should reject response', async () => {
-		const res = new Response('{"error": "error"}', { status: 400 })
+		const res = new Response('{"message": "error"}', { status: 400 })
 		try {
 			await resolveResponse(res)
 		} catch (err) {
 			expect(err).toBeInstanceOf(FetchError)
 			if (!isFetchError(err)) throw new Error('Invalid error')
-			expect(err.body).toEqual({ error: 'error' })
-			if (!isErrorBody(err.body)) throw new Error('Invalid error body')
-			expect(err.message).to.eql(err.body.error)
+			expect(err.body).toEqual({ message: 'error' })
+			expect(err.message).to.eql('Request failed')
 		}
 	})
 	it('should reject text response', async () => {
@@ -42,7 +40,7 @@ describe('resolveResponse', () => {
 			expect(err).toBeInstanceOf(FetchError)
 			if (!isFetchError(err)) return
 			expect(err.body).toEqual('Not found')
-			expect(err.message).to.eql('Request failed - Not found')
+			expect(err.message).to.eql('Request failed')
 		}
 	})
 })

--- a/packages/fetch/src/resolveResponse.ts
+++ b/packages/fetch/src/resolveResponse.ts
@@ -1,13 +1,12 @@
 import { FetchError } from './FetchError.js'
-import { isErrorBody } from './isErrorBody.js'
-import { ErrorBody, FetchResponse, ResolveResponseOptions } from './types.js'
+import { FetchResponse, ResolveResponseOptions } from './types.js'
 
 /**
  * This is an example resolver that will read and parse the response body and throw a FetchError if the response is not ok.
  * Assumes all response bodies include a string prop `error` for error messages. You can extend these further in your own code
  * base with additional type assertions
  */
-export async function resolveResponse<T, E extends ErrorBody>(res: FetchResponse<T, E>, options: ResolveResponseOptions = {}): Promise<T | null> {
+export async function resolveResponse<T = never, E = unknown>(res: FetchResponse<T, E>, options: ResolveResponseOptions = {}): Promise<T | null> {
 	const text = await res.text() // can only await content once between json() and text(); so we'll do it by hand.
 	if (options.resolveWithResponseBody) return text as unknown as T // T is assumed string
 	let body: unknown
@@ -21,6 +20,6 @@ export async function resolveResponse<T, E extends ErrorBody>(res: FetchResponse
 		return null
 	}
 
-	if (isErrorBody(body)) throw new FetchError<E>(body.error, res.status, body as E)
-	throw new FetchError<E>(`Request failed - ${text}`, res.status, text)
+	if (body != null) throw new FetchError<E>('Request failed', res.status, body as E) // kind of forcing type assertion here.
+	throw new FetchError<E>('Request failed', res.status, text)
 }

--- a/packages/fetch/src/types.ts
+++ b/packages/fetch/src/types.ts
@@ -24,8 +24,6 @@ export interface IdBody { id: string }
 
 export type WithId<T> = Omit<T, 'id'> & IdBody
 
-export interface ErrorBody { error: string, stack?: string }
-
 export interface AffectedBody { count: number }
 
 export type DataBody<T> = Omit<Partial<T>, 'id'>


### PR DESCRIPTION
Small tweaks to error handling; dropping opinions on error response structure. 

 - Dropping assumptions on the response error (no longer requires `error` and `stack` props. 
 - `toString()` on `FetchError` will attempt to read `message`, and `error` props for printing
 - `FetchError` does make one assumption: if `JSON.parse` succeeds and `res.ok === false` then it assumes the body type is `E`